### PR TITLE
Add settings panel with theme and styling controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta charset="utf-8" />
   <title>Finance Calculators</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
-  <meta name="color-scheme" content="light" />
+  <meta name="color-scheme" content="light dark" />
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -37,7 +37,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-slate-50 text-slate-900 antialiased">
+<body class="antialiased">
   <!-- Ambient blobs -->
   <div class="pointer-events-none fixed inset-0 -z-10">
     <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>

--- a/script.js
+++ b/script.js
@@ -43,6 +43,25 @@ React.createElement(IconLink, { href: SOCIALS.tiktok, label: "TikTok" }, /*#__PU
 
 
 
+
+/* ----------------------- Settings ----------------------- */
+function SettingsPanel({ config, onChange }) {
+  return /*#__PURE__*/(
+    React.createElement("div", { className: "absolute top-full right-0 mt-2 w-56 p-4 space-y-3 tooltip-panel z-50" }, /*#__PURE__*/
+    React.createElement("div", null, /*#__PURE__*/
+    React.createElement("label", { className: "block text-xs font-medium mb-1" }, "Theme"), /*#__PURE__*/
+    React.createElement("select", { className: "field", value: config.theme, onChange: e => onChange('theme', e.target.value) }, /*#__PURE__*/
+    React.createElement("option", { value: "light" }, "Light"), /*#__PURE__*/React.createElement("option", { value: "dark" }, "Dark"))), /*#__PURE__*/
+    React.createElement("div", null, /*#__PURE__*/
+    React.createElement("label", { className: "block text-xs font-medium mb-1" }, "Accent"), /*#__PURE__*/
+    React.createElement("select", { className: "field", value: config.accent, onChange: e => onChange('accent', e.target.value) }, /*#__PURE__*/
+    React.createElement("option", { value: "slate" }, "Slate"), /*#__PURE__*/React.createElement("option", { value: "emerald" }, "Emerald"), /*#__PURE__*/React.createElement("option", { value: "amber" }, "Amber"))), /*#__PURE__*/
+    React.createElement("div", null, /*#__PURE__*/
+    React.createElement("label", { className: "block text-xs font-medium mb-1" }, "Font size"), /*#__PURE__*/
+    React.createElement("select", { className: "field", value: config.font, onChange: e => onChange('font', e.target.value) }, /*#__PURE__*/
+    React.createElement("option", { value: "base" }, "Base"), /*#__PURE__*/React.createElement("option", { value: "small" }, "Small"), /*#__PURE__*/React.createElement("option", { value: "large" }, "Large")))));
+}
+
 /* ----------------------- Formatters & math ----------------------- */
 const money0 = n => {var _window$accounting$fo, _window$accounting, _window$accounting$fo2;return (_window$accounting$fo = (_window$accounting = window.accounting) === null || _window$accounting === void 0 ? void 0 : (_window$accounting$fo2 = _window$accounting.formatMoney) === null || _window$accounting$fo2 === void 0 ? void 0 : _window$accounting$fo2.call(_window$accounting, n !== null && n !== void 0 ? n : 0, { precision: 0 })) !== null && _window$accounting$fo !== void 0 ? _window$accounting$fo :
   (n !== null && n !== void 0 ? n : 0).toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });};
@@ -1379,13 +1398,31 @@ function FunFacts({ topic }) {
   return /*#__PURE__*/(
     React.createElement("div", { className: "mt-4 px-4 py-3 bg-white border rounded-xl flex items-center justify-between gap-3 shadow-card" }, /*#__PURE__*/
     React.createElement("span", { className: "text-sm text-slate-700" }, fact), /*#__PURE__*/
-    React.createElement("button", { className: "kbd", onClick: shuffle, title: "Shuffle fun fact" }, "\uD83D\uDD00")));
+    React.createElement("button", {
+      className: "icon-btn hover:bg-slate-100 transition-colors duration-150",
+      onClick: shuffle,
+      title: "Shuffle fun fact",
+      "aria-label": "Shuffle fun fact",
+      style: { background: "transparent" }
+    }, "\uD83D\uDD00\uFE0F")));
 }
 
 /* --------------------------------- App --------------------------------- */
 function App() {
   const [view, setView] = useState('home');
   const [placeholders, setPlaceholders] = useState(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settings, setSettings] = useLocalStorage('settings', { theme: 'light', accent: 'slate', font: 'base' });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = settings.theme;
+    document.documentElement.dataset.accent = settings.accent;
+    document.documentElement.dataset.font = settings.font;
+    const meta = document.querySelector('meta[name=color-scheme]');
+    if (meta) meta.setAttribute('content', settings.theme === 'dark' ? 'dark light' : 'light dark');
+  }, [settings]);
+
+  const updateSetting = (k, v) => setSettings(s => ({ ...s, [k]: v }));
 
   return /*#__PURE__*/(
     React.createElement("div", { className: "max-w-5xl mx-auto px-4 py-6" }, /*#__PURE__*/
@@ -1399,8 +1436,11 @@ function App() {
 
 
 
-    React.createElement("div", { className: "flex flex-col items-end gap-2" }, /*#__PURE__*/
+    React.createElement("div", { className: "flex flex-col items-end gap-2 relative" }, /*#__PURE__*/
+    React.createElement("div", { className: "flex items-center gap-2" }, /*#__PURE__*/
     React.createElement(SocialBar, null), /*#__PURE__*/
+    React.createElement("button", { className: "icon-btn hover:bg-slate-100 transition-colors duration-150", onClick: () => setSettingsOpen(o => !o), "aria-label": "Settings", title: "Settings" }, "\u2699\uFE0F")), /*#__PURE__*/
+    settingsOpen && /*#__PURE__*/React.createElement(SettingsPanel, { config: settings, onChange: updateSetting }), /*#__PURE__*/
     React.createElement("span", { className: "text-[11px] text-slate-500" }, "@luisitin2001"))), /*#__PURE__*/
 
 

--- a/style.css
+++ b/style.css
@@ -1,58 +1,97 @@
-:root { --ring: 0 0 0 3px rgba(99,102,241,.35); }
+:root {
+  --ring: 0 0 0 3px rgba(99,102,241,.35);
+  --bg: #f8fafc;
+  --text: #0f172a;
+  --border: #e2e8f0;
+  --card-bg: rgba(255,255,255,.8);
+  --input-bg: #fff;
+  --input-text: #0f172a;
+  --accent: #0f172a;
+  --accent-text: #fff;
+  --result-bg1: #f8fafc;
+  --result-bg2: #eef2f7;
+  --tag-bg: #f1f5f9;
+  --tag-text: #334155;
+  --base-font-size: 16px;
+}
 
-.card { border: 1px solid #e2e8f0; background: rgba(255,255,255,.8); border-radius: .75rem; box-shadow: 0 1px 2px rgba(0,0,0,.04); }
+html { font-size: var(--base-font-size); }
+body { background: var(--bg); color: var(--text); }
+
+[data-theme='dark'] {
+  --bg: #0f172a;
+  --text: #f8fafc;
+  --card-bg: rgba(30,41,59,.8);
+  --border: #334155;
+  --input-bg: #1e293b;
+  --input-text: #f8fafc;
+  --result-bg1: #1e293b;
+  --result-bg2: #0f172a;
+  --tag-bg: #334155;
+  --tag-text: #f1f5f9;
+}
+
+[data-accent='slate'] { --accent: #0f172a; --accent-text: #fff; }
+[data-accent='emerald'] { --accent: #047857; --accent-text: #fff; }
+[data-accent='amber'] { --accent: #b45309; --accent-text: #fff; }
+
+[data-font='small'] { --base-font-size: 14px; }
+[data-font='large'] { --base-font-size: 18px; }
+
+.card { border:1px solid var(--border); background: var(--card-bg); border-radius:.75rem; box-shadow:0 1px 2px rgba(0,0,0,.04); }
 
 .field {
-  width: 100%;
-  border: 1px solid #e2e8f0;
-  border-radius: .625rem;
-  padding: .6rem .75rem;
-  background: #fff;
-  line-height: 1.25;
-  font-size: .925rem;
-  color: #0f172a;
+  width:100%;
+  border:1px solid var(--border);
+  border-radius:.625rem;
+  padding:.6rem .75rem;
+  background: var(--input-bg);
+  line-height:1.25;
+  font-size:.925rem;
+  color: var(--input-text);
 }
-.field:focus { outline: none; border-color:#6366f1; box-shadow: var(--ring); }
+.field:focus { outline:none; border-color:#6366f1; box-shadow: var(--ring); }
 
 .kbd {
   display:inline-flex;align-items:center;gap:.5rem;
-  padding:.5rem .75rem;border-radius:.6rem;border:1px solid #e2e8f0;
-  background:#0f172a;color:#fff;font-weight:600;font-size:.85rem;
+  padding:.5rem .75rem;border-radius:.6rem;border:1px solid var(--border);
+  background:var(--accent);color:var(--accent-text);font-weight:600;font-size:.85rem;
   transition:filter .15s ease, transform .06s ease;
 }
 .kbd:hover{filter:brightness(1.05)} .kbd:active{transform:translateY(1px)}
 
-.tab-btn { box-shadow: 0 1px 0 rgba(0,0,0,.03); }
+.tab-btn { box-shadow:0 1px 0 rgba(0,0,0,.03); }
 .tabs-scroll { overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:thin; scrollbar-color:#cbd5e1 transparent; }
 .tabs-scroll::-webkit-scrollbar { height:8px; }
 .tabs-scroll::-webkit-scrollbar-thumb { background:#cbd5e1; border-radius:999px; }
 
 .mono { font-variant-numeric: tabular-nums; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace; }
-.hover\:shadow-card:hover { box-shadow: var(--card, 0 10px 30px rgba(2,6,23,.10), 0 2px 8px rgba(2,6,23,.06)); }
+.hover\\:shadow-card:hover { box-shadow: var(--card, 0 10px 30px rgba(2,6,23,.10), 0 2px 8px rgba(2,6,23,.06)); }
 
-.icon-btn { width:1.8rem; height:1.8rem; display:grid; place-items:center; border-radius:.5rem; border:1px solid #e2e8f0; color:#64748b; }
-.tooltip-panel { border:1px solid #e2e8f0; border-radius:.75rem; background:#fff; box-shadow:0 10px 30px rgba(2,6,23,.12),0 2px 8px rgba(2,6,23,.08); }
+.icon-btn { width:1.8rem; height:1.8rem; display:grid; place-items:center; border-radius:.5rem; border:1px solid var(--accent); background: var(--input-bg); color: var(--accent); }
+
+.tooltip-panel { border:1px solid var(--border); border-radius:.75rem; background:var(--input-bg); box-shadow:0 10px 30px rgba(2,6,23,.12),0 2px 8px rgba(2,6,23,.08); }
 .animate-fadeUp { animation: fadeUp .5s cubic-bezier(.2,.7,.2,1) both; }
 @keyframes fadeUp { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }
 
 /* result tiles: subtle gradient gray */
 .result {
-  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
-  border: 1px solid #e2e8f0;
-  border-radius: .75rem;
-  padding: .75rem;
+  background: linear-gradient(180deg, var(--result-bg1) 0%, var(--result-bg2) 100%);
+  border:1px solid var(--border);
+  border-radius:.75rem;
+  padding:.75rem;
 }
 
 /* balance sheet table (net worth) */
 .bs-table { width:100%; border-collapse:separate; border-spacing:0 6px; }
 .bs-table th { text-align:left; font-size:.8rem; color:#64748b; padding:0 .5rem .25rem; }
-.bs-row { background:#fff; border:1px solid #e2e8f0; border-radius:.75rem; overflow:hidden; }
+.bs-row { background:var(--input-bg); border:1px solid var(--border); border-radius:.75rem; overflow:hidden; }
 .bs-cell { padding:.65rem .75rem; }
 .bs-dot { width:.85rem; height:.85rem; border-radius:999px; display:inline-block; margin-right:.5rem; }
 
 /* tiny color tags used across sections */
-.tag { display:inline-block; padding:.15rem .45rem; font-size:.7rem; border-radius:.4rem; background:#f1f5f9; border:1px solid #e2e8f0; color:#334155; }
+.tag { display:inline-block; padding:.15rem .45rem; font-size:.7rem; border-radius:.4rem; background:var(--tag-bg); border:1px solid var(--border); color:var(--tag-text); }
 
 /* helper for (i) info badges */
-.info-btn { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; font-size:12px; font-weight:700; border-radius:999px; border:1px solid #cbd5e1; color:#475569; background:#f8fafc; margin-left:.35rem; }
-.info-pop { position:absolute; z-index:30; inset: auto auto auto 0; transform: translateY(4px); min-width: 14rem; }
+.info-btn { display:inline-flex; align-items:center; justify-content:center; width:18px; height:18px; font-size:12px; font-weight:700; border-radius:999px; border:1px solid var(--border); color:#475569; background:var(--tag-bg); margin-left:.35rem; }
+.info-pop { position:absolute; z-index:30; inset:auto auto auto 0; transform:translateY(4px); min-width:14rem; }


### PR DESCRIPTION
## Summary
- add configurable settings panel with theme, accent, and font size options
- support dark mode and accent variables through new CSS custom properties
- allow HTML color-scheme to include dark mode
- make shuffle fun-fact button use transparent icon styling
- ensure settings panel overlays content and applies selections to page styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689fb38156a88322a472f38376cf3b59