### PR TITLE
Fix settings panel overlap and dark mode background

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-slate-50 text-slate-900 antialiased">
+<body class="antialiased">
   <!-- Ambient blobs -->
   <div class="pointer-events-none fixed inset-0 -z-10">
     <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>

--- a/script.js
+++ b/script.js
@@ -47,7 +47,7 @@ React.createElement(IconLink, { href: SOCIALS.tiktok, label: "TikTok" }, /*#__PU
 /* ----------------------- Settings ----------------------- */
 function SettingsPanel({ config, onChange }) {
   return /*#__PURE__*/(
-    React.createElement("div", { className: "absolute top-full right-0 z-[9999] mt-2 w-56 p-4 border rounded-xl bg-white shadow-card space-y-3" }, /*#__PURE__*/
+    React.createElement("div", { className: "absolute top-full right-0 mt-2 w-56 p-4 border rounded-xl bg-white shadow-card space-y-3", style: { zIndex: 1000 } }, /*#__PURE__*/
     React.createElement("div", null, /*#__PURE__*/
     React.createElement("label", { className: "block text-xs font-medium mb-1" }, "Theme"), /*#__PURE__*/
     React.createElement("select", { className: "field", value: config.theme, onChange: e => onChange('theme', e.target.value) }, /*#__PURE__*/

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@
   --base-font-size: 16px;
 }
 
-html { font-size: var(--base-font-size); }
+html { font-size: var(--base-font-size); background: var(--bg); }
 body { background: var(--bg); color: var(--text); }
 
 [data-theme='dark'] {


### PR DESCRIPTION
## Summary
- ensure settings panel overlays tabs using high z-index
- allow body and html background to follow theme for dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe5b88f588322bfd3686273f2a09a