### PR TITLE
Fix city autofill and default light theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" >
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <title>Finance-Calcs</title>

--- a/script.js
+++ b/script.js
@@ -153,7 +153,7 @@ async function fetchMedianIncomeByZip(zip) {
 }
 async function fetchCitySuggestions(q) {
   if (!q) return [];
-  const url = `https://secure.geonames.org/postalCodeSearchJSON?placename=${encodeURIComponent(q)}&country=US&maxRows=5&username=demo`;
+  const url = `https://api.geonames.org/postalCodeSearchJSON?placename_startsWith=${encodeURIComponent(q)}&country=US&maxRows=5&username=demo`;
   const r = await fetch(url);
   if (!r.ok) return [];
   const j = await r.json();


### PR DESCRIPTION
## Summary
- fix city search to use GeoNames API for suggestions
- set HTML root to light theme by default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a001d0b3a08322a3451afc10800a0e