### PR TITLE
feat: enable theme toggle and city suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
 <head>
-  <meta charset="UTF-8">
-  <title>Finance-Calcs</title>
-  <link rel="stylesheet" href="./style.css">
-
-</head>
-<body>
-<!-- partial:index.partial.html -->
-<html lang="en">
-<head>
   <meta charset="utf-8" />
   <title>Finance Calculators</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="color-scheme" content="light dark" />
-
-  <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     tailwind.config = {
@@ -32,12 +21,11 @@
       }
     }
   </script>
-
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="antialiased">
+<body class="bg-slate-50 text-slate-900 antialiased">
   <!-- Ambient blobs -->
   <div class="pointer-events-none fixed inset-0 -z-10">
     <div class="absolute -top-24 -left-24 w-72 h-72 rounded-full bg-gradient-to-br from-amber-200 to-pink-200 blur-3xl opacity-60 animate-floaty"></div>
@@ -70,14 +58,5 @@
 
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="script.js"></script>
-</body>
-</html>
-<!-- partial -->
-  <script src='https://cdn.jsdelivr.net/npm/mathjs@14.6.0/lib/browser/math.js'></script>
-<script src='https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js'></script>
-<script src='https://cdn.jsdelivr.net/npm/chart.js'></script>
-<script src='https://cdn.jsdelivr.net/npm/accounting-js@2.0.3/dist/accounting.umd.min.js'></script>
-<script src='https://cdn.jsdelivr.net/npm/xirr@1.1.0/xirr.js'></script><script  src="./script.js"></script>
-
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -34,8 +34,8 @@ React.createElement("a", { href: href, target: "_blank", rel: "noreferrer",
 children);
 
 
-const InstagramSVG = () => /*#__PURE__*/React.createElement("img", { src: "instagram.svg", width: "16", height: "16", alt: "", "aria-hidden": "true" });
-const TikTokSVG = () => /*#__PURE__*/React.createElement("img", { src: "tiktok.svg", width: "16", height: "16", alt: "", "aria-hidden": "true" });
+const InstagramSVG = () => /*#__PURE__*/React.createElement("img", { src: "instagram.svg", width: "16", height: "16", alt: "", "aria-hidden": "true", className: "social-icon" });
+const TikTokSVG = () => /*#__PURE__*/React.createElement("img", { src: "tiktok.svg", width: "16", height: "16", alt: "", "aria-hidden": "true", className: "social-icon" });
 const SocialBar = () => /*#__PURE__*/
 React.createElement("div", { className: "flex items-center gap-2" }, /*#__PURE__*/
 React.createElement(IconLink, { href: SOCIALS.instagram, label: "Instagram" }, /*#__PURE__*/React.createElement(InstagramSVG, null)), /*#__PURE__*/
@@ -154,11 +154,16 @@ async function fetchMedianIncomeByZip(zip) {
 async function fetchCitySuggestions(q) {
   if (!q) return [];
   const url = `https://api.geonames.org/postalCodeSearchJSON?placename_startsWith=${encodeURIComponent(q)}&country=US&maxRows=5&username=demo`;
-  const r = await fetch(url);
-  if (!r.ok) return [];
-  const j = await r.json();
-  const arr = Array.isArray(j.postalCodes) ? j.postalCodes : [];
-  return arr.map(p => ({ city: p.placeName, state: p.adminCode1, zip: p.postalCode }));
+  try {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error('geoNames error');
+    const j = await r.json();
+    const arr = Array.isArray(j.postalCodes) ? j.postalCodes : [];
+    return arr.map(p => ({ city: p.placeName, state: p.adminCode1, zip: p.postalCode }));
+  } catch (e) {
+    console.warn('City suggestion fetch failed', e);
+    return [];
+  }
 }
 
 /* ----------------------- Micro UI ----------------------- */
@@ -1134,7 +1139,7 @@ function DataPanel({ onPlaceholders }) {
   useEffect(() => { refresh(); }, []);
   useEffect(() => {
     let active = true;
-    if (cityQuery.length < 2) { setSuggestions([]); return; }
+    if (cityQuery.length < 3) { setSuggestions([]); return; }
     fetchCitySuggestions(cityQuery).then(list => { if (active) setSuggestions(list); }).catch(_ => {});
     return () => { active = false; };
   }, [cityQuery]);
@@ -1461,6 +1466,12 @@ function App() {
     document.documentElement.dataset.theme = settings.theme;
     document.documentElement.dataset.accent = settings.accent;
     document.documentElement.dataset.font = settings.font;
+    document.body.classList.remove('bg-slate-50', 'text-slate-900', 'bg-slate-900', 'text-slate-50');
+    if (settings.theme === 'dark') {
+      document.body.classList.add('bg-slate-900', 'text-slate-50');
+    } else {
+      document.body.classList.add('bg-slate-50', 'text-slate-900');
+    }
     const meta = document.querySelector('meta[name=color-scheme]');
     if (meta) meta.setAttribute('content', settings.theme === 'dark' ? 'dark light' : 'light dark');
   }, [settings]);
@@ -1482,7 +1493,7 @@ function App() {
     React.createElement("div", { className: "flex flex-col items-end gap-2 relative" }, /*#__PURE__*/
     React.createElement("div", { className: "flex items-center gap-2" }, /*#__PURE__*/
     React.createElement(SocialBar, null), /*#__PURE__*/
-    React.createElement("button", { className: "icon-btn hover:bg-slate-100 transition-colors duration-150", onClick: () => setSettingsOpen(o => !o), "aria-label": "Settings", title: "Settings" }, "\u2699\uFE0F")), /*#__PURE__*/
+    React.createElement("button", { className: "icon-btn hover:bg-slate-100 transition-colors duration-150", onClick: () => setSettingsOpen(o => !o), "aria-label": "Settings", title: "Settings", "aria-expanded": settingsOpen }, "\u2699\uFE0F")), /*#__PURE__*/
     settingsOpen && /*#__PURE__*/React.createElement(SettingsPanel, { config: settings, onChange: updateSetting }), /*#__PURE__*/
     React.createElement("span", { className: "text-[11px] text-slate-500" }, "@luisitin2001"))), /*#__PURE__*/
 

--- a/style.css
+++ b/style.css
@@ -71,6 +71,9 @@ body { background: var(--bg); color: var(--text); }
 .icon-btn { width:1.8rem; height:1.8rem; display:grid; place-items:center; border-radius:.5rem; border:1px solid var(--border); background: var(--input-bg); color:#64748b; }
 [data-theme='dark'] .icon-btn { color:#cbd5e1; }
 
+.social-icon { transition:filter .2s ease; }
+[data-theme='dark'] .social-icon { filter:invert(1); }
+
 .tooltip-panel { border:1px solid var(--border); border-radius:.75rem; background:var(--input-bg); box-shadow:0 10px 30px rgba(2,6,23,.12),0 2px 8px rgba(2,6,23,.08); }
 .animate-fadeUp { animation: fadeUp .5s cubic-bezier(.2,.7,.2,1) both; }
 @keyframes fadeUp { from{opacity:0;transform:translateY(6px)} to{opacity:1;transform:translateY(0)} }


### PR DESCRIPTION
## Summary
- rely exclusively on GeoNames API for city suggestions
- apply body class swapping so theme changes reflect immediately
- require three letters before requesting city suggestions
- invert social icons when dark theme is active
- expose settings button state for accessible toggling

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0037dd7f88322afdf4d5f6472d50d