### PR TITLE
feat: integrate gpt-4.1 question widget

### DIFF
--- a/gpt.js
+++ b/gpt.js
@@ -1,0 +1,32 @@
+const apiKey = ''; // TODO: Replace with your OpenAI API key
+
+async function askGPT() {
+  const questionInput = document.getElementById('question-input');
+  const answerDiv = document.getElementById('answer');
+  const question = questionInput.value.trim();
+  if (!question) return;
+
+  answerDiv.textContent = 'Thinking...';
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4.1',
+        input: question
+      })
+    });
+
+    const data = await res.json();
+    const text = data?.output?.[0]?.content?.[0]?.text?.value || 'No answer';
+    answerDiv.textContent = text;
+  } catch (err) {
+    answerDiv.textContent = 'Error: ' + err.message;
+  }
+}
+
+document.getElementById('ask-btn')?.addEventListener('click', askGPT);

--- a/index.html
+++ b/index.html
@@ -35,6 +35,16 @@
   <!-- React mount -->
   <main id="root" class="min-h-screen"></main>
 
+  <!-- Simple GPT-4.1 demo -->
+  <section id="ai-ask" class="max-w-2xl mx-auto p-4">
+    <h2 class="text-xl font-semibold mb-2">Ask AI</h2>
+    <div class="flex gap-2">
+      <input id="question-input" class="flex-grow border rounded p-2" placeholder="Ask a question" />
+      <button id="ask-btn" class="bg-blue-500 text-white px-4 py-2 rounded">Ask</button>
+    </div>
+    <div id="answer" class="mt-2 text-slate-700"></div>
+  </section>
+
   <noscript>
     <div class="max-w-lg mx-auto p-6 m-4 rounded-xl border bg-white text-slate-800">
       <h2 class="text-xl font-semibold mb-2">JavaScript is required</h2>
@@ -58,5 +68,6 @@
 
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="script.js"></script>
+  <script src="gpt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple GPT-4.1 question/answer section to the static site
- include JS helper that calls OpenAI's gpt-4.1 model

## Testing
- `node -v`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Finance/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b465c87483228601e3cb33f7507b