### PR TITLE
Use OpenAI chat model for Ask AI demo

### DIFF
--- a/gpt.js
+++ b/gpt.js
@@ -9,21 +9,22 @@ async function askGPT() {
   answerDiv.textContent = 'Thinking...';
 
   try {
-    const res = await fetch('https://api.openai.com/v1/responses', {
+    // Use the general OpenAI chat model so the AI always provides a reply
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${apiKey}`
       },
       body: JSON.stringify({
-        model: 'gpt-4.1',
-        input: question
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: question }]
       })
     });
 
     const data = await res.json();
-    const text = data?.output?.[0]?.content?.[0]?.text?.value || 'No answer';
-    answerDiv.textContent = text;
+    const text = data?.choices?.[0]?.message?.content?.trim();
+    answerDiv.textContent = text || "I'm not sure, but I couldn't find an answer.";
   } catch (err) {
     answerDiv.textContent = 'Error: ' + err.message;
   }

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
   <!-- React mount -->
   <main id="root" class="min-h-screen"></main>
 
-  <!-- Simple GPT-4.1 demo -->
+  <!-- Simple OpenAI chat demo -->
   <section id="ai-ask" class="max-w-2xl mx-auto p-4">
     <h2 class="text-xl font-semibold mb-2">Ask AI</h2>
     <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- Switch Ask AI feature to OpenAI's gpt-4o-mini chat model and ensure a fallback response
- Update demo comment to reference the generic OpenAI chat example

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check gpt.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0b6bb77d4832295a6b9f075ed7f15