### PR TITLE
Handle missing transformers library in GPT demo

### DIFF
--- a/gpt.js
+++ b/gpt.js
@@ -4,8 +4,11 @@ async function loadModel() {
   const answerDiv = document.getElementById('answer');
   try {
     answerDiv.textContent = 'Loading model...';
-    const { pipeline } = window.transformers;
-    generator = await pipeline('text-generation', 'Xenova/gpt2');
+    const transformers = window.transformers;
+    if (!transformers || typeof transformers.pipeline !== 'function') {
+      throw new Error('Transformers library not loaded');
+    }
+    generator = await transformers.pipeline('text-generation', 'Xenova/gpt2');
   } catch (err) {
     answerDiv.textContent = 'Failed to load model: ' + err.message;
     throw err;


### PR DESCRIPTION
## Summary
- avoid destructuring from undefined by checking the availability of `window.transformers`
- surface a clear error message if the Transformers library fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c9a26b688322b28b45000a6a55af