### PR TITLE
Use server-side chat API with streaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,6 @@
 
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="script.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@xenova/transformers/dist/transformers.min.js"></script>
   <script src="gpt.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove local `@xenova/transformers` model usage
- Stream chat responses from `/api/chat` and update UI incrementally
- Drop unused transformers script from index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22a5aa0f083229334e46791ae9d7f