### PR TITLE
Serve app at root path

### DIFF
--- a/server.js
+++ b/server.js
@@ -100,6 +100,7 @@ app.post('/api/chat', async (req, res) => {
 });
 
 app.use(express.static('public'));
+app.use('/finance', express.static('public'));
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- Serve static assets at `/` and `/finance` so the calculators load directly from the root URL.

## Testing
- `npm test`
- `npm run dev`
- `curl -i http://localhost:3000/`
- `curl -i http://localhost:3000/finance/`


------
https://chatgpt.com/codex/tasks/task_e_68a230af9b7883229ca325209d4b45a4