### PR TITLE
Fix Monte Carlo simulations rendering

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1216,7 +1216,7 @@ function Simulations() {
     });
   }, [results]);
 
-  return /*#__PURE__*/(
+  return /*#__PURE__*/React.createElement(React.Fragment, null,
     React.createElement(Section, { title: "Monte Carlo Simulations" }, /*#__PURE__*/
     React.createElement("div", { className: "grid sm:grid-cols-3 gap-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Simulation" }, /*#__PURE__*/React.createElement("select", { className: "field", value: simType, onChange: e => setSimType(e.target.value) }, /*#__PURE__*/React.createElement("option", { value: "growth" }, "Investment Growth"), /*#__PURE__*/React.createElement("option", { value: "retire" }, "Retirement Outcome"))), /*#__PURE__*/
@@ -1252,8 +1252,8 @@ function Simulations() {
       simType === 'retire' && /*#__PURE__*/React.createElement("div", { className: "result col-span-3" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Success chance"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, (results.success * 100).toFixed(1), "%"))), /*#__PURE__*/
     React.createElement("canvas", { ref: canvasRef, height: "200", className: "mt-4" }), /*#__PURE__*/
     React.createElement("p", { className: "text-xs text-slate-600 mt-2" }, simType === 'growth' ? 'Histogram of final balances across simulations. Percentiles show optimistic and conservative scenarios.' : 'Histogram of ending balances. Success chance is the percentage of trials with money left.' ))),
-    /*#__PURE__*/React.createElement("p", { className: "text-xs text-slate-500 mt-2" }, "Sources: ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-1", className: "underline" }, "[1]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-2", className: "underline" }, "[2]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-3", className: "underline" }, "[3]")),
-    /*#__PURE__*/React.createElement("ol", { className: "text-xs text-slate-500 list-decimal list-inside mt-1" }, /*#__PURE__*/
+    React.createElement("p", { className: "text-xs text-slate-500 mt-2" }, "Sources: ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-1", className: "underline" }, "[1]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-2", className: "underline" }, "[2]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-3", className: "underline" }, "[3]")),
+    React.createElement("ol", { className: "text-xs text-slate-500 list-decimal list-inside mt-1" }, /*#__PURE__*/
       React.createElement("li", { id: "sim-src-1" }, /*#__PURE__*/React.createElement("a", { className: "underline", href: "https://www.investopedia.com/terms/m/montecarlosimulation.asp", target: "_blank", rel: "noreferrer" }, "Investopedia \u2013 Monte Carlo Simulation"), " (free to read; \u00a9 Dotdash Meredith)."), /*#__PURE__*/
       React.createElement("li", { id: "sim-src-2" }, /*#__PURE__*/React.createElement("a", { className: "underline", href: "https://www.troweprice.com/financial-intermediary/us/en/insights/articles/2022/q2/monte-carlo-simulations-retirement-planning.html", target: "_blank", rel: "noreferrer" }, "T. Rowe Price \u2013 Monte Carlo simulations: what a good success rate looks like"), " (\u00a9 T. Rowe Price; online article)."), /*#__PURE__*/
       React.createElement("li", { id: "sim-src-3" }, /*#__PURE__*/React.createElement("a", { className: "underline", href: "https://investor.vanguard.com/investor-resources-education/article/plan-for-retirement-using-monte-carlo-simulations", target: "_blank", rel: "noreferrer" }, "Vanguard \u2013 Plan for retirement using Monte Carlo simulations"), " (\u00a9 Vanguard; online article).")


### PR DESCRIPTION
## Summary
- Wrap Monte Carlo Simulations content in a React fragment so the section, description, and source list render together

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a390742a8883228f9812b36de2fff3