### PR TITLE
Centralize simulation horizon defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,6 @@
 
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="components/SourceNote.jsx"></script>
-  <script type="text/babel" data-presets="env,react" src="public/script.js"></script>
+  <script type="text/babel" data-type="module" data-presets="env,react" src="public/script.js"></script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -2,6 +2,7 @@
    Tweaks in this version:
    - Debt Payoff: extra placeholder = $0; "+ Add debt" moved under list.
 */
+import { HORIZON_DEFAULTS } from '../sim/horizonDefaults.js';
 const { useState, useMemo, useEffect, useRef } = React;
 
 /* ----------------------- Error Boundary ----------------------- */
@@ -1133,17 +1134,18 @@ function SocialSecurity() {
 }
 
 /* ----------------------- Monte Carlo simulations ----------------------- */
-function Simulations() {
-  const [simType, setSimType] = useState('growth');
+function Simulations({ horizonDefaults }) {
+  const [horizon, setHorizon] = useState('growth');
+  const defaults = horizonDefaults[horizon];
   const [mode, setMode] = useState('simple');
   const [start, setStart] = useState();
   const [contrib, setContrib] = useState();
   const [withdraw, setWithdraw] = useState();
   const [years, setYears] = useState();
-  const [mean, setMean] = useState(7);
-  const [vol, setVol] = useState(15);
-  const [trials, setTrials] = useState(1000);
-  const [infl, setInfl] = useState(2);
+  const [mean, setMean] = useState(defaults.mean);
+  const [vol, setVol] = useState(defaults.vol);
+  const [trials, setTrials] = useState(defaults.trials);
+  const [infl, setInfl] = useState(defaults.infl);
   const [results, setResults] = useState(null);
   const canvasRef = useRef(null);
   const chartRef = useRef(null);
@@ -1171,7 +1173,7 @@ function Simulations() {
       let ok = true;
       for (let y = 0; y < yrs; y++) {
         const r = randomNormal(m, s);
-        if (simType === 'growth') {
+        if (horizon === 'growth') {
           const c = mode === 'advanced' ? contribVal * Math.pow(1 + inf, y) : contribVal;
           bal = (bal + c) * (1 + r);
         } else {
@@ -1181,7 +1183,7 @@ function Simulations() {
         }
       }
       finals.push(bal);
-      if (simType === 'retire' && ok) success++;
+      if (horizon === 'retire' && ok) success++;
     }
     finals.sort((a, b) => a - b);
     const pct = p => finals[Math.floor(p * finals.length)];
@@ -1189,10 +1191,20 @@ function Simulations() {
       p10: pct(0.1),
       median: pct(0.5),
       p90: pct(0.9),
-      success: simType === 'retire' ? success / n : undefined,
+      success: horizon === 'retire' ? success / n : undefined,
       data: finals
     });
   };
+
+  useEffect(() => {
+    setStart();
+    setContrib();
+    setWithdraw();
+    setMean(defaults.mean);
+    setVol(defaults.vol);
+    setTrials(defaults.trials);
+    setInfl(defaults.infl);
+  }, [horizon]);
 
   useEffect(() => {
     if (!results || !window.Chart || !canvasRef.current) return;
@@ -1219,27 +1231,27 @@ function Simulations() {
   return /*#__PURE__*/React.createElement(React.Fragment, null,
     React.createElement(Section, { title: "Monte Carlo Simulations" }, /*#__PURE__*/
     React.createElement("div", { className: "grid sm:grid-cols-3 gap-3" }, /*#__PURE__*/
-    React.createElement(Field, { label: "Simulation" }, /*#__PURE__*/React.createElement("select", { className: "field", value: simType, onChange: e => setSimType(e.target.value) }, /*#__PURE__*/React.createElement("option", { value: "growth" }, "Investment Growth"), /*#__PURE__*/React.createElement("option", { value: "retire" }, "Retirement Outcome"))), /*#__PURE__*/
+    React.createElement(Field, { label: "Simulation" }, /*#__PURE__*/React.createElement("select", { className: "field", value: horizon, onChange: e => setHorizon(e.target.value) }, /*#__PURE__*/React.createElement("option", { value: "growth" }, "Investment Growth"), /*#__PURE__*/React.createElement("option", { value: "retire" }, "Retirement Outcome"))), /*#__PURE__*/
     React.createElement(Field, { label: "Mode" }, /*#__PURE__*/React.createElement("select", { className: "field", value: mode, onChange: e => setMode(e.target.value) }, /*#__PURE__*/React.createElement("option", { value: "simple" }, "Simple"), /*#__PURE__*/React.createElement("option", { value: "advanced" }, "Advanced"))), /*#__PURE__*/
     React.createElement(Field, { label: "Years" }, /*#__PURE__*/React.createElement(NumberInput, { value: years, onChange: setYears, step: "1", placeholder: "30" }))),
 
-    simType === 'growth' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
-    React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(10000) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Annual contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: contrib, onChange: setContrib, placeholder: money0(6000) })),
+    horizon === 'growth' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
+    React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(defaults.start) })), /*#__PURE__*/
+    React.createElement(Field, { label: "Annual contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: contrib, onChange: setContrib, placeholder: money0(defaults.contrib) })),
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
-    React.createElement(Field, { label: "Mean return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: "15" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
-    React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: "1000" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: "2" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Mean return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(defaults.mean) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(defaults.vol) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(defaults.trials) })), /*#__PURE__*/
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(defaults.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
 
-    simType === 'retire' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
-    React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(500000) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Annual withdrawal" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: withdraw, onChange: setWithdraw, placeholder: money0(40000) })),
+    horizon === 'retire' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
+    React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(defaults.start) })), /*#__PURE__*/
+    React.createElement(Field, { label: "Annual withdrawal" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: withdraw, onChange: setWithdraw, placeholder: money0(defaults.withdraw) })),
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
-    React.createElement(Field, { label: "Mean return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: "5" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: "12" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
-    React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: "1000" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: "2" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Mean return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(defaults.mean) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(defaults.vol) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(defaults.trials) })), /*#__PURE__*/
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(defaults.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
 
     React.createElement("div", { className: "mt-3" }, /*#__PURE__*/
     React.createElement("button", { className: "kbd", onClick: run }, "Run")),
@@ -1249,9 +1261,9 @@ function Simulations() {
       React.createElement("div", { className: "result" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "10th percentile"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(results.p10))), /*#__PURE__*/
       React.createElement("div", { className: "result" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Median"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(results.median))), /*#__PURE__*/
       React.createElement("div", { className: "result" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "90th percentile"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(results.p90))), /*#__PURE__*/
-      simType === 'retire' && /*#__PURE__*/React.createElement("div", { className: "result col-span-3" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Success chance"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, (results.success * 100).toFixed(1), "%"))), /*#__PURE__*/
+      horizon === 'retire' && /*#__PURE__*/React.createElement("div", { className: "result col-span-3" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Success chance"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, (results.success * 100).toFixed(1), "%"))), /*#__PURE__*/
     React.createElement("canvas", { ref: canvasRef, height: "200", className: "mt-4" }), /*#__PURE__*/
-    React.createElement("p", { className: "text-xs text-slate-600 mt-2" }, simType === 'growth' ? 'Histogram of final balances across simulations. Percentiles show optimistic and conservative scenarios.' : 'Histogram of ending balances. Success chance is the percentage of trials with money left.' ))),
+    React.createElement("p", { className: "text-xs text-slate-600 mt-2" }, horizon === 'growth' ? 'Histogram of final balances across simulations. Percentiles show optimistic and conservative scenarios.' : 'Histogram of ending balances. Success chance is the percentage of trials with money left.' ))),
     React.createElement("p", { className: "text-xs text-slate-500 mt-2" }, "Sources: ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-1", className: "underline" }, "[1]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-2", className: "underline" }, "[2]"), ", ", /*#__PURE__*/React.createElement("a", { href: "#sim-src-3", className: "underline" }, "[3]")),
     React.createElement("ol", { className: "text-xs text-slate-500 list-decimal list-inside mt-1" }, /*#__PURE__*/
       React.createElement("li", { id: "sim-src-1" }, /*#__PURE__*/React.createElement("a", { className: "underline", href: "https://www.investopedia.com/terms/m/montecarlosimulation.asp", target: "_blank", rel: "noreferrer" }, "Investopedia \u2013 Monte Carlo Simulation"), " (free to read; \u00a9 Dotdash Meredith)."), /*#__PURE__*/
@@ -1692,7 +1704,7 @@ function App() {
     view === 'networth' && /*#__PURE__*/React.createElement(NetWorth, null),
     view === 'tax' && /*#__PURE__*/React.createElement(TaxCalc, null),
     view === 'ss' && /*#__PURE__*/React.createElement(SocialSecurity, null),
-    view === 'sim' && /*#__PURE__*/React.createElement(Simulations, null),
+    view === 'sim' && /*#__PURE__*/React.createElement(Simulations, { horizonDefaults: HORIZON_DEFAULTS }),
     view === 'data' && /*#__PURE__*/React.createElement(DataPanel, { onPlaceholders: setPlaceholders })), /*#__PURE__*/
 
 

--- a/sim/horizonDefaults.js
+++ b/sim/horizonDefaults.js
@@ -1,0 +1,18 @@
+export const HORIZON_DEFAULTS = {
+  growth: {
+    start: 10000,
+    contrib: 6000,
+    mean: 7,
+    vol: 15,
+    trials: 1000,
+    infl: 2
+  },
+  retire: {
+    start: 500000,
+    withdraw: 40000,
+    mean: 5,
+    vol: 12,
+    trials: 1000,
+    infl: 2
+  }
+};


### PR DESCRIPTION
## Summary
- add `sim/horizonDefaults.js` with reusable default values for investment growth and retirement horizons
- load horizon defaults in `public/script.js` and wire into `Simulations`
- drive initial state and placeholders from constants for consistent resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39544a20883228372c87e33752e69