### PR TITLE
fix: serve static assets for calculators

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,14 @@ const path = require('path');
 
 const app = express();
 
-app.use('/public', express.static('public'));
+// Serve static assets used by the front-end. Previously only the `public`
+// directory was exposed which meant files like `/components/SourceNote.jsx`
+// and modules imported from `/sim` returned 404s in the browser. React would
+// then fail to load and the page rendered blank. Expose those directories so
+// the client can fetch them.
+app.use('/public', express.static(path.join(__dirname, 'public')));
+app.use('/components', express.static(path.join(__dirname, 'components')));
+app.use('/sim', express.static(path.join(__dirname, 'sim')));
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });


### PR DESCRIPTION
## Summary
- serve components and simulation modules through Express static middleware
- document why missing static assets caused blank page

## Testing
- `npm test`
- `curl -I http://localhost:3000/components/SourceNote.jsx`
- `curl -I http://localhost:3000/sim/horizonDefaults.js`


------
https://chatgpt.com/codex/tasks/task_e_68a39a80457c83228290211a53f2951f