### PR TITLE
chore: disable Jekyll on GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+Prevent GitHub Pages from using Jekyll


### PR DESCRIPTION
## Summary
- Add .nojekyll so GitHub Pages serves JSX and module files directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a39ba3e22c83229a0a0cfde8107252