### PR TITLE
Use LazyPortfolioETF data for returns and risk

### DIFF
--- a/components/SourceNote.jsx
+++ b/components/SourceNote.jsx
@@ -1,31 +1,14 @@
-const SourceNote = ({ url, details, dispersionUrl }) => /*#__PURE__*/(
-  React.createElement(
-    "p",
-    { className: "text-[11px] text-slate-500 mt-1" },
-    "Source: ",
-    React.createElement(
-      "a",
-      { href: url, target: "_blank", rel: "noreferrer", className: "underline" },
-      "Slickcharts"
-    ),
-    details ? ` — ${details}` : '',
-    dispersionUrl &&
-      /*#__PURE__*/ React.createElement(
-        React.Fragment,
-        null,
-        " · ",
-        React.createElement(
-          "a",
-          {
-            href: dispersionUrl,
-            target: "_blank",
-            rel: "noreferrer",
-            className: "underline"
-          },
-          "LazyPortfolioETF"
-        )
-      )
-  )
+const SourceNote = ({ url, details, name = "LazyPortfolioETF" }) =>
+/*#__PURE__*/ React.createElement(
+  "p",
+  { className: "text-[11px] text-slate-500 mt-1" },
+  "Source: ",
+  /*#__PURE__*/ React.createElement(
+    "a",
+    { href: url, target: "_blank", rel: "noreferrer", className: "underline" },
+    name
+  ),
+  details ? ` — ${details}` : ''
 );
 
 // No export here so the component is available globally when loaded via script tag

--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
     </div>
   </noscript>
 
+  <footer class="text-center text-sm text-slate-500 m-4">
+    Past performance is not indicative of future performance.
+  </footer>
+
   <!-- React 18 UMD -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>

--- a/public/script.js
+++ b/public/script.js
@@ -15,7 +15,7 @@ const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   },
   retire: {
@@ -25,19 +25,24 @@ const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   }
 };
 
 const HORIZON_DEFAULTS = {
-  1: { expectedReturn: 5, volatility: 20 },
-  5: { expectedReturn: 6, volatility: 18 },
-  10: { expectedReturn: 7, volatility: 15 },
-  15: { expectedReturn: 7, volatility: 14 },
-  20: { expectedReturn: 7, volatility: 13 },
-  30: { expectedReturn: 7, volatility: 12 }
+  1: { expectedReturn: 8.69, volatility: 11.56 },
+  5: { expectedReturn: 8.69, volatility: 11.56 },
+  10: { expectedReturn: 8.58, volatility: 10.5 },
+  15: { expectedReturn: 8.58, volatility: 10.5 },
+  20: { expectedReturn: 8.25, volatility: 9.68 },
+  30: { expectedReturn: 8.25, volatility: 9.68 }
 };
+
+let INVESTOR_PROFILE = '60/40';
+fetch('/api/config').then(r => r.json()).then(cfg => {
+  INVESTOR_PROFILE = cfg.investorProfile;
+});
 
 const horizonFromYears = y => {
   if (y < 5) return 1;
@@ -509,7 +514,7 @@ function CompoundCalc() {
     React.createElement("div", { className: "grid sm:grid-cols-4 gap-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Starting amount" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: principal, onChange: setPrincipal, placeholder: money0(10000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Monthly contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: monthly, onChange: setMonthly, placeholder: money0(500) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "8" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year return (60/40) ~8.6%" })), /*#__PURE__*/
     React.createElement(Field, { label: "Years" }, /*#__PURE__*/React.createElement(NumberInput, { value: years, onChange: setYears, step: "1", placeholder: "30" }))), /*#__PURE__*/
 
     React.createElement(CompoundResults, { principal: principal, monthly: monthly, ret: ret, years: years })));
@@ -520,7 +525,7 @@ function CompoundResults({ principal, monthly, ret, years }) {
   const fv = useMemo(() => futureValue({
     principal: principal !== null && principal !== void 0 ? principal : 10000,
     monthly: monthly !== null && monthly !== void 0 ? monthly : 500,
-    apr: ret !== null && ret !== void 0 ? ret : 7,
+    apr: ret !== null && ret !== void 0 ? ret : 8,
     years: years !== null && years !== void 0 ? years : 30 }),
   [principal, monthly, ret, years]);
   const contrib = (principal !== null && principal !== void 0 ? principal : 10000) + (monthly !== null && monthly !== void 0 ? monthly : 500) * months(years !== null && years !== void 0 ? years : 30);
@@ -543,7 +548,7 @@ function RetirementGoal() {
   const req = useMemo(() => requiredMonthly({
     goal: goal !== null && goal !== void 0 ? goal : 1000000,
     principal: current !== null && current !== void 0 ? current : 50000,
-    apr: ret !== null && ret !== void 0 ? ret : 7, years: years !== null && years !== void 0 ? years : 30 }),
+    apr: ret !== null && ret !== void 0 ? ret : 8, years: years !== null && years !== void 0 ? years : 30 }),
   [goal, current, ret, years]);
 
   return /*#__PURE__*/(
@@ -552,7 +557,7 @@ function RetirementGoal() {
     React.createElement(Field, { label: "Goal (future value)" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: goal, onChange: setGoal, placeholder: money0(1000000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Current saved" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: current, onChange: setCurrent, placeholder: money0(50000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Years" }, /*#__PURE__*/React.createElement(NumberInput, { value: years, onChange: setYears, step: "1", placeholder: "30" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%", dispersionUrl: "https://www.lazyportfolioetf.com/" }))), /*#__PURE__*/
+    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "8" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year return (60/40) ~8.6%" }))), /*#__PURE__*/
 
     React.createElement("div", { className: "result mt-3" }, /*#__PURE__*/
     React.createElement("div", { className: "text-xs text-slate-500" }, "Required monthly contribution"), /*#__PURE__*/
@@ -1291,26 +1296,26 @@ function Simulations({ scenarioDefaults }) {
     scenario === 'growth' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(scenarioDef.start) })), /*#__PURE__*/
     React.createElement(Field, { label: "Annual contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: contrib, onChange: setContrib, placeholder: money0(scenarioDef.contrib) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year return (60/40) 8.58%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year volatility (60/40) 10.50%" })), /*#__PURE__*/
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
     React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(scenarioDef.trials) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.bls.gov/cpi/", name: "BLS CPI", details: "10-year CPI ~2%" })))),
 
     scenario === 'retire' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(scenarioDef.start) })), /*#__PURE__*/
     React.createElement(Field, { label: "Annual withdrawal" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: withdraw, onChange: setWithdraw, placeholder: money0(scenarioDef.withdraw) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year return (60/40) 8.58%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: "10-year volatility (60/40) 10.50%" })), /*#__PURE__*/
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
     React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(scenarioDef.trials) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.bls.gov/cpi/", name: "BLS CPI", details: "10-year CPI ~2%" })))),
 
     trailing && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
     React.createElement("div", { className: "result mt-3" }, /*#__PURE__*/
     React.createElement("div", { className: "text-xs text-slate-500" }, `Last ${trailing.years} years`), /*#__PURE__*/
     React.createElement("div", { className: "text-lg font-semibold" }, `${trailing.cagr}% annualized`)), /*#__PURE__*/
-    React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: `${trailing.years}-year CAGR ending 2024` })),
+    React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", name: "LazyPortfolioETF", details: `${trailing.years}-year return ending 2024` })),
 
     React.createElement("div", { className: "mt-3" }, /*#__PURE__*/
     React.createElement("button", { className: "kbd", onClick: run }, "Run")),

--- a/server.js
+++ b/server.js
@@ -15,6 +15,11 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });
 
+const investorProfile = process.env.INVESTOR_PROFILE || '60/40';
+app.get('/api/config', (req, res) => {
+  res.json({ investorProfile });
+});
+
 const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Server listening on http://localhost:${port}`);

--- a/sim/horizonDefaults.js
+++ b/sim/horizonDefaults.js
@@ -6,7 +6,7 @@ export const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   },
   retire: {
@@ -16,18 +16,56 @@ export const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   }
 };
 
 export const HORIZON_DEFAULTS = {
-  1: { expectedReturn: 5, volatility: 20 },
-  5: { expectedReturn: 6, volatility: 18 },
-  10: { expectedReturn: 7, volatility: 15 },
-  15: { expectedReturn: 7, volatility: 14 },
-  20: { expectedReturn: 7, volatility: 13 },
-  30: { expectedReturn: 7, volatility: 12 }
+  1: { expectedReturn: 8.69, volatility: 11.56 },
+  5: { expectedReturn: 8.69, volatility: 11.56 },
+  10: { expectedReturn: 8.58, volatility: 10.5 },
+  15: { expectedReturn: 8.58, volatility: 10.5 },
+  20: { expectedReturn: 8.25, volatility: 9.68 },
+  30: { expectedReturn: 8.25, volatility: 9.68 }
+};
+
+export const INVESTOR_PROFILE_STATS = {
+  superAggressiveTech: {
+    '5y': { return: 16.96, stddev: 20.33 },
+    '10y': { return: 18.47, stddev: 18.72 },
+    '30y': { return: 13.74, stddev: 23.99 }
+  },
+  aggressive: {
+    '5y': { return: 15.11, stddev: 16.38 },
+    '10y': { return: 12.97, stddev: 15.89 },
+    '30y': { return: 10.3, stddev: 15.65 }
+  },
+  modAggressive: {
+    '5y': { return: 11.91, stddev: 13.92 },
+    '10y': { return: 10.79, stddev: 13.13 },
+    '30y': { return: 9.35, stddev: 12.58 }
+  },
+  moderate: {
+    '5y': { return: 8.69, stddev: 11.56 },
+    '10y': { return: 8.58, stddev: 10.5 },
+    '30y': { return: 8.25, stddev: 9.68 }
+  },
+  modConservative: {
+    '5y': { return: 5.44, stddev: 9.39 },
+    '10y': { return: 6.31, stddev: 8.09 },
+    '30y': { return: 7.01, stddev: 7.02 }
+  },
+  conservative: {
+    '5y': { return: 2.15, stddev: 7.54 },
+    '10y': { return: 4.0, stddev: 6.12 },
+    '30y': { return: 5.64, stddev: 4.93 }
+  },
+  superConservative: {
+    '5y': { return: -1.16, stddev: 6.32 },
+    '10y': { return: 1.63, stddev: 5.14 },
+    '30y': { return: 4.14, stddev: 4.24 }
+  }
 };
 
 export function horizonFromYears(y) {


### PR DESCRIPTION
## Summary
- replace Slickcharts references with LazyPortfolioETF and BLS CPI sources
- update return/volatility defaults and add investor profile configuration
- add footnote noting past performance is not indicative of future results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a7e4db54832280d72afbe8e35cf7