### PR TITLE
Use LazyPortfolioETF data and add investor profile setting

### DIFF
--- a/components/SourceNote.jsx
+++ b/components/SourceNote.jsx
@@ -1,4 +1,4 @@
-const SourceNote = ({ url, details, dispersionUrl }) => /*#__PURE__*/(
+const SourceNote = ({ url, details }) => /*#__PURE__*/(
   React.createElement(
     "p",
     { className: "text-[11px] text-slate-500 mt-1" },
@@ -6,25 +6,9 @@ const SourceNote = ({ url, details, dispersionUrl }) => /*#__PURE__*/(
     React.createElement(
       "a",
       { href: url, target: "_blank", rel: "noreferrer", className: "underline" },
-      "Slickcharts"
+      "LazyPortfolioETF"
     ),
-    details ? ` — ${details}` : '',
-    dispersionUrl &&
-      /*#__PURE__*/ React.createElement(
-        React.Fragment,
-        null,
-        " · ",
-        React.createElement(
-          "a",
-          {
-            href: dispersionUrl,
-            target: "_blank",
-            rel: "noreferrer",
-            className: "underline"
-          },
-          "LazyPortfolioETF"
-        )
-      )
+    details ? ` — ${details}` : ''
   )
 );
 

--- a/index.html
+++ b/index.html
@@ -41,6 +41,10 @@
     </div>
   </noscript>
 
+  <footer class="text-center text-xs text-slate-500 my-4">
+    Past performance is not indicative of future performance.
+  </footer>
+
   <!-- React 18 UMD -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>

--- a/public/script.js
+++ b/public/script.js
@@ -509,7 +509,7 @@ function CompoundCalc() {
     React.createElement("div", { className: "grid sm:grid-cols-4 gap-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Starting amount" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: principal, onChange: setPrincipal, placeholder: money0(10000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Monthly contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: monthly, onChange: setMonthly, placeholder: money0(500) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year return ~8.58%" })), /*#__PURE__*/
     React.createElement(Field, { label: "Years" }, /*#__PURE__*/React.createElement(NumberInput, { value: years, onChange: setYears, step: "1", placeholder: "30" }))), /*#__PURE__*/
 
     React.createElement(CompoundResults, { principal: principal, monthly: monthly, ret: ret, years: years })));
@@ -552,7 +552,7 @@ function RetirementGoal() {
     React.createElement(Field, { label: "Goal (future value)" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: goal, onChange: setGoal, placeholder: money0(1000000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Current saved" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: current, onChange: setCurrent, placeholder: money0(50000) })), /*#__PURE__*/
     React.createElement(Field, { label: "Years" }, /*#__PURE__*/React.createElement(NumberInput, { value: years, onChange: setYears, step: "1", placeholder: "30" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%", dispersionUrl: "https://www.lazyportfolioetf.com/" }))), /*#__PURE__*/
+    React.createElement(Field, { label: "Return (annual)" }, /*#__PURE__*/React.createElement(PercentInput, { value: ret, onChange: setRet, placeholder: "7" }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year return ~8.58%" }))), /*#__PURE__*/
 
     React.createElement("div", { className: "result mt-3" }, /*#__PURE__*/
     React.createElement("div", { className: "text-xs text-slate-500" }, "Required monthly contribution"), /*#__PURE__*/
@@ -1290,25 +1290,25 @@ function Simulations({ scenarioDefaults }) {
     React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(scenarioDef.start) })), /*#__PURE__*/
     React.createElement(Field, { label: "Annual contribution" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: contrib, onChange: setContrib, placeholder: money0(scenarioDef.contrib) })), /*#__PURE__*/
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
-    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year return ~8.58%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year stdev ~10.50%" })), /*#__PURE__*/
     React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(scenarioDef.trials) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) })))),
 
     scenario === 'retire' && /*#__PURE__*/React.createElement("div", { className: "grid sm:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
     React.createElement(Field, { label: "Starting balance" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: start, onChange: setStart, placeholder: money0(scenarioDef.start) })), /*#__PURE__*/
     React.createElement(Field, { label: "Annual withdrawal" }, /*#__PURE__*/React.createElement(CurrencyInput, { value: withdraw, onChange: setWithdraw, placeholder: money0(scenarioDef.withdraw) })), /*#__PURE__*/
     mode === 'advanced' && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
-    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CAGR ~12%" })), /*#__PURE__*/
-    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year volatility ~15%", dispersionUrl: "https://www.lazyportfolioetf.com/" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Expected return" }, /*#__PURE__*/React.createElement(PercentInput, { value: mean, onChange: setMean, placeholder: String(horizonDef.expectedReturn) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year return ~8.58%" })), /*#__PURE__*/
+    React.createElement(Field, { label: "Volatility" }, /*#__PURE__*/React.createElement(PercentInput, { value: vol, onChange: setVol, placeholder: String(horizonDef.volatility) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: "Moderate 60/40 10-year stdev ~10.50%" })), /*#__PURE__*/
     React.createElement(Field, { label: "# Trials" }, /*#__PURE__*/React.createElement(NumberInput, { value: trials, onChange: setTrials, step: "1", placeholder: String(scenarioDef.trials) })), /*#__PURE__*/
-    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) }), /*#__PURE__*/React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: "10-year CPI ~2%" })))),
+    React.createElement(Field, { label: "Inflation" }, /*#__PURE__*/React.createElement(PercentInput, { value: infl, onChange: setInfl, placeholder: String(scenarioDef.infl) })))),
 
     trailing && /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/
     React.createElement("div", { className: "result mt-3" }, /*#__PURE__*/
     React.createElement("div", { className: "text-xs text-slate-500" }, `Last ${trailing.years} years`), /*#__PURE__*/
     React.createElement("div", { className: "text-lg font-semibold" }, `${trailing.cagr}% annualized`)), /*#__PURE__*/
-    React.createElement(SourceNote, { url: "https://www.slickcharts.com/sp500", details: `${trailing.years}-year CAGR ending 2024` })),
+    React.createElement(SourceNote, { url: "https://www.lazyportfolioetf.com/", details: `${trailing.years}-year return ending 2024` })),
 
     React.createElement("div", { className: "mt-3" }, /*#__PURE__*/
     React.createElement("button", { className: "kbd", onClick: run }, "Run")),

--- a/server.js
+++ b/server.js
@@ -3,6 +3,9 @@ const path = require('path');
 
 const app = express();
 
+const INVESTOR_PROFILE = process.env.INVESTOR_PROFILE || '60/40';
+app.locals.investorProfile = INVESTOR_PROFILE;
+
 // Serve static assets used by the front-end. Previously only the `public`
 // directory was exposed which meant files like `/components/SourceNote.jsx`
 // and modules imported from `/sim` returned 404s in the browser. React would

--- a/sim/horizonDefaults.js
+++ b/sim/horizonDefaults.js
@@ -6,7 +6,7 @@ export const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   },
   retire: {
@@ -16,18 +16,22 @@ export const SCENARIO_DEFAULTS = {
     infl: 2,
     trailing_cagr_ending_2024: {
       years: 10,
-      cagr: 12
+      cagr: 8.58
     }
   }
 };
 
+export const INVESTOR_PROFILE = '60/40';
+
+// Expected return and volatility approximations for a 60/40 portfolio
+// Source: https://www.lazyportfolioetf.com/
 export const HORIZON_DEFAULTS = {
-  1: { expectedReturn: 5, volatility: 20 },
-  5: { expectedReturn: 6, volatility: 18 },
-  10: { expectedReturn: 7, volatility: 15 },
-  15: { expectedReturn: 7, volatility: 14 },
-  20: { expectedReturn: 7, volatility: 13 },
-  30: { expectedReturn: 7, volatility: 12 }
+  1: { expectedReturn: 8.69, volatility: 11.56 },
+  5: { expectedReturn: 8.69, volatility: 11.56 },
+  10: { expectedReturn: 8.58, volatility: 10.5 },
+  15: { expectedReturn: 8.5, volatility: 10.3 },
+  20: { expectedReturn: 8.42, volatility: 10.09 },
+  30: { expectedReturn: 8.25, volatility: 9.68 }
 };
 
 export function horizonFromYears(y) {

--- a/sim/investorProfiles.js
+++ b/sim/investorProfiles.js
@@ -1,0 +1,41 @@
+// Portfolio return and volatility data
+// Source: https://www.lazyportfolioetf.com/
+export const INVESTOR_PROFILES = {
+  superAggressive: {
+    allocation: 'All Tech',
+    returns: { 5: 16.96, 10: 18.47, 30: 13.74 },
+    stddev: { 5: 20.33, 10: 18.72, 30: 23.99 }
+  },
+  aggressive: {
+    allocation: '100/0',
+    returns: { 5: 15.11, 10: 12.97, 30: 10.3 },
+    stddev: { 5: 16.38, 10: 15.89, 30: 15.65 }
+  },
+  modAggressive: {
+    allocation: '80/20',
+    returns: { 5: 11.91, 10: 10.79, 30: 9.35 },
+    stddev: { 5: 13.92, 10: 13.13, 30: 12.58 }
+  },
+  moderate: {
+    allocation: '60/40',
+    returns: { 5: 8.69, 10: 8.58, 30: 8.25 },
+    stddev: { 5: 11.56, 10: 10.5, 30: 9.68 }
+  },
+  modConservative: {
+    allocation: '40/60',
+    returns: { 5: 5.44, 10: 6.31, 30: 7.01 },
+    stddev: { 5: 9.39, 10: 8.09, 30: 7.02 }
+  },
+  conservative: {
+    allocation: '20/80',
+    returns: { 5: 2.15, 10: 4.0, 30: 5.64 },
+    stddev: { 5: 7.54, 10: 6.12, 30: 4.93 }
+  },
+  superConservative: {
+    allocation: '0/100',
+    returns: { 5: -1.16, 10: 1.63, 30: 4.14 },
+    stddev: { 5: 6.32, 10: 5.14, 30: 4.24 }
+  }
+};
+
+export const DEFAULT_INVESTOR_PROFILE = 'moderate';


### PR DESCRIPTION
## Summary
- replace Slickcharts references with LazyPortfolioETF citations
- add investor profile configuration defaulting to 60/40 and supply portfolio return data
- include disclaimer that past performance does not guarantee future results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a9b323d883229493d852a4e6728f