### PR TITLE
Use scenario defaults in simulation run fallback values

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1207,14 +1207,14 @@ function Simulations({ scenarioDefaults }) {
   };
 
   const run = () => {
-    const yrs = Number(years) || 30;
+    const yrs = Number(years ?? 30);
     const m = ((mean ?? '') === '' ? horizonDef.expectedReturn : Number(mean)) / 100;
     const s = ((vol ?? '') === '' ? horizonDef.volatility : Number(vol)) / 100;
-    const n = Number(trials) || scenarioDef.trials;
-    const inf = (Number(infl) || 0) / 100;
-    const startVal = Number(start) || 0;
-    const contribVal = Number(contrib) || 0;
-    const withdrawVal = Number(withdraw) || 0;
+    const n = (trials ?? '') === '' ? scenarioDef.trials : Number(trials);
+    const inf = ((infl ?? '') === '' ? scenarioDef.infl : Number(infl)) / 100;
+    const startVal = Number(start ?? scenarioDef.start);
+    const contribVal = Number(contrib ?? scenarioDef.contrib);
+    const withdrawVal = Number(withdraw ?? scenarioDef.withdraw);
     const finals = [];
     let success = 0;
     for (let t = 0; t < n; t++) {


### PR DESCRIPTION
## Summary
- Ensure Monte Carlo `run` function uses scenario defaults instead of zero fallbacks for trials, inflation, starting balance, contributions and withdrawals
- Handle optional input for years without overriding explicit zero

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac479ce8832280f387460c604315