### PR TITLE
Use opaque card backgrounds

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,7 +3,7 @@
   --bg: #f8fafc;
   --text: #0f172a;
   --border: #e2e8f0;
-  --card-bg: rgba(255,255,255,.8);
+  --card-bg: #fff;
   --input-bg: #fff;
   --input-text: #0f172a;
   --accent: #0f172a;
@@ -21,7 +21,7 @@ body { background: var(--bg); color: var(--text); }
 [data-theme='dark'] {
   --bg: #0f172a;
   --text: #f8fafc;
-  --card-bg: rgba(30,41,59,.8);
+  --card-bg: #1e293b;
   --border: #334155;
   --input-bg: #1e293b;
   --input-text: #f8fafc;


### PR DESCRIPTION
## Summary
- switch `--card-bg` variables in light and dark themes to solid colors

## Testing
- `npm test`
- `node server.js` (fetched `public/style.css` to confirm solid card backgrounds)


------
https://chatgpt.com/codex/tasks/task_e_68a51263410483228c43a7eb19f55061