### PR TITLE
Fix CPI series ID for economic data fetch

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1734,7 +1734,8 @@ function DataPanel({ onPlaceholders }) {
       const yyyymm = yy + mm;
       const dateKey = `${yy}-${mm}-01`;
       const [cpiSeries, unrateSeries, tsy10, ffSeries] = await Promise.all([
-        getBLS('CUUR0000SA0'),
+        // Use seasonally adjusted CPI-U series to match other economic helpers
+        getBLS('CUSR0000SA0'),
         getBLS('LNS14000000'),
         getTreasury10Y(yyyymm),
         getFREDFedFundsCSV()


### PR DESCRIPTION
## Summary
- Use seasonally adjusted CPI-U (CUSR0000SA0) when fetching economic data
- Document series choice inline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a3c98c50832286cbed15d17abc99