### PR TITLE
feat: allow configurable CORS origin

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,24 @@
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    const origin = request.headers.get("Origin") || "*";
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          "Access-Control-Allow-Origin": origin,
+          "Access-Control-Allow-Methods": "GET,HEAD,POST,OPTIONS",
+          "Access-Control-Allow-Headers": request.headers.get("Access-Control-Request-Headers") || "",
+        },
+      });
+    }
+
+    const resp = await fetch(url, request);
+    const modified = new Response(resp.body, resp);
+    modified.headers.set("Access-Control-Allow-Origin", origin);
+    modified.headers.set("Access-Control-Allow-Methods", "GET,HEAD,POST,OPTIONS");
+    modified.headers.set("Access-Control-Allow-Headers", "*");
+    return modified;
+  },
+};


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker script that mirrors requests and sets CORS headers based on the request's `Origin`

## Testing
- `npm test`
- `npx --yes wrangler deploy worker.js` *(fails: CLOUDFLARE_API_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d3dbe2d4832297f1ab34e5cc2580