### PR TITLE
Add API data panel with FRED, Treasury, and BLS options

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,13 @@
   <!-- Babel (JSX + ESNext in the browser) -->
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
-  <!-- Your app (JSX) -->
+  <!-- App components and helper libraries (loaded via Babel in-browser) -->
   <script type="text/babel" data-presets="env,react" src="components/SourceNote.jsx"></script>
+  <script type="text/babel" data-presets="env,react" src="public/config.js"></script>
+  <script type="text/babel" data-presets="env,react" src="public/lib/proxy.js"></script>
+  <script type="text/babel" data-presets="env,react" src="public/lib/bls.js"></script>
+  <script type="text/babel" data-presets="env,react" src="public/lib/fred.js"></script>
+  <script type="text/babel" data-presets="env,react" src="public/lib/treasury.js"></script>
   <script type="text/babel" data-presets="env,react" src="public/script.js"></script>
 </body>
 </html>

--- a/public/config.js
+++ b/public/config.js
@@ -1,2 +1,5 @@
-export const PROXY = "https://autumn-dew-1295.luisitinrodriguez2001.workers.dev/cors/?url=";
+// Expose the proxy URL on the global object so it can be consumed by
+// other scripts without relying on ES module imports. This avoids the
+// blank-page issue when the app is loaded via a classic script tag.
+window.PROXY = "https://autumn-dew-1295.luisitinrodriguez2001.workers.dev/cors/?url=";
 

--- a/public/lib/bls.js
+++ b/public/lib/bls.js
@@ -1,8 +1,7 @@
-import { proxiedFetch } from './proxy.js';
-
 const BLS_BASE = 'https://api.bls.gov/publicAPI/v2/timeseries/data';
 
-export function blsFetchSingle(seriesId, { startyear, endyear, ...rest } = {}) {
+// Expose BLS helper functions globally so they can be used without modules.
+function blsFetchSingle(seriesId, { startyear, endyear, ...rest } = {}) {
   const params = new URLSearchParams();
   if (startyear) params.set('startyear', startyear);
   if (endyear) params.set('endyear', endyear);
@@ -11,18 +10,20 @@ export function blsFetchSingle(seriesId, { startyear, endyear, ...rest } = {}) {
   }
   const qs = params.toString();
   const url = `${BLS_BASE}/${encodeURIComponent(seriesId)}${qs ? `?${qs}` : ''}`;
-  return proxiedFetch(url);
+  return window.proxiedFetch(url);
 }
 
-export function blsFetchMany(seriesIds, { startyear, endyear, key } = {}) {
+function blsFetchMany(seriesIds, { startyear, endyear, key } = {}) {
   const body = { seriesid: seriesIds };
   if (startyear) body.startyear = startyear;
   if (endyear) body.endyear = endyear;
   if (key) body.registrationkey = key;
-  return proxiedFetch(BLS_BASE, {
+  return window.proxiedFetch(BLS_BASE, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
 }
 
+window.blsFetchSingle = blsFetchSingle;
+window.blsFetchMany = blsFetchMany;

--- a/public/lib/fred.js
+++ b/public/lib/fred.js
@@ -1,13 +1,12 @@
-import { proxiedFetch } from './proxy.js';
-
 const FRED_BASE = 'https://api.stlouisfed.org/fred/series/observations';
 
-export function fredSeriesObservations({ series_id, api_key, params = {} }) {
+// Expose FRED helper globally for non-module environments.
+function fredSeriesObservations({ series_id, api_key, params = {} }) {
   const search = new URLSearchParams({ series_id, api_key, file_type: 'json' });
   for (const [k, v] of Object.entries(params)) {
     if (v != null) search.set(k, v);
   }
   const url = `${FRED_BASE}?${search.toString()}`;
-  return proxiedFetch(url);
+  return window.proxiedFetch(url);
 }
-
+window.fredSeriesObservations = fredSeriesObservations;

--- a/public/lib/proxy.js
+++ b/public/lib/proxy.js
@@ -1,10 +1,12 @@
-import { PROXY } from "../config.js";
-
-export function proxiedFetch(targetUrl, init) {
+// Access the PROXY constant from the global scope instead of importing so the
+// script can run without ES module support in the browser.
+function proxiedFetch(targetUrl, init) {
   if (typeof targetUrl !== "string" || !/^https?:\/\//i.test(targetUrl)) {
     throw new Error("proxiedFetch expects an absolute URL");
   }
-  const url = PROXY + encodeURIComponent(targetUrl);
+  const url = window.PROXY + encodeURIComponent(targetUrl);
   return fetch(url, init);
 }
 
+// Attach to window for global consumption.
+window.proxiedFetch = proxiedFetch;

--- a/public/lib/treasury.js
+++ b/public/lib/treasury.js
@@ -1,14 +1,13 @@
-import { proxiedFetch } from './proxy.js';
-
 const TREASURY_BASE = 'https://api.fiscaldata.treasury.gov/services/api/fiscal_service';
 
-export function treasuryQuery(datasetPath, params = {}) {
+// Expose Treasury query helper globally for non-module usage.
+function treasuryQuery(datasetPath, params = {}) {
   const search = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
     if (v != null) search.set(k, v);
   }
   const qs = search.toString();
   const url = `${TREASURY_BASE}/${datasetPath}${qs ? `?${qs}` : ''}`;
-  return proxiedFetch(url);
+  return window.proxiedFetch(url);
 }
-
+window.treasuryQuery = treasuryQuery;


### PR DESCRIPTION
## Summary
- Replace old placeholder DataPanel with a new panel that queries FRED, Treasury Fiscal Data, or BLS APIs
- Support multiple BLS series IDs and API keys for each service; display source note and documentation links
- Load API helper scripts without ES modules to fix blank page rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e38df4cc83228b72296c5f08c893