### PR TITLE
Add helper guards and proxy fallback

### DIFF
--- a/public/lib/bls.js
+++ b/public/lib/bls.js
@@ -10,7 +10,13 @@ function blsFetchSingle(seriesId, { startyear, endyear, ...rest } = {}) {
   }
   const qs = params.toString();
   const url = `${BLS_BASE}/${encodeURIComponent(seriesId)}${qs ? `?${qs}` : ''}`;
-  return window.proxiedFetch(url);
+  if (typeof window.proxiedFetch === 'function') {
+    return window.proxiedFetch(url);
+  }
+  const msg = 'proxiedFetch is not available';
+  console.error(msg);
+  if (typeof alert === 'function') alert(msg);
+  throw new Error(msg);
 }
 
 function blsFetchMany(seriesIds, { startyear, endyear, key } = {}) {
@@ -18,11 +24,17 @@ function blsFetchMany(seriesIds, { startyear, endyear, key } = {}) {
   if (startyear) body.startyear = startyear;
   if (endyear) body.endyear = endyear;
   if (key) body.registrationkey = key;
-  return window.proxiedFetch(BLS_BASE, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  });
+  if (typeof window.proxiedFetch === 'function') {
+    return window.proxiedFetch(BLS_BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+  }
+  const msg = 'proxiedFetch is not available';
+  console.error(msg);
+  if (typeof alert === 'function') alert(msg);
+  throw new Error(msg);
 }
 
 window.blsFetchSingle = blsFetchSingle;

--- a/public/lib/fred.js
+++ b/public/lib/fred.js
@@ -7,6 +7,12 @@ function fredSeriesObservations({ series_id, api_key, params = {} }) {
     if (v != null) search.set(k, v);
   }
   const url = `${FRED_BASE}?${search.toString()}`;
-  return window.proxiedFetch(url);
+  if (typeof window.proxiedFetch === "function") {
+    return window.proxiedFetch(url);
+  }
+  const msg = "proxiedFetch is not available";
+  console.error(msg);
+  if (typeof alert === "function") alert(msg);
+  throw new Error(msg);
 }
 window.fredSeriesObservations = fredSeriesObservations;

--- a/public/lib/proxy.js
+++ b/public/lib/proxy.js
@@ -4,8 +4,18 @@ function proxiedFetch(targetUrl, init) {
   if (typeof targetUrl !== "string" || !/^https?:\/\//i.test(targetUrl)) {
     throw new Error("proxiedFetch expects an absolute URL");
   }
-  const url = window.PROXY + encodeURIComponent(targetUrl);
-  return fetch(url, init);
+  if (typeof window.PROXY === "string" && window.PROXY.length > 0) {
+    const url = window.PROXY + encodeURIComponent(targetUrl);
+    return fetch(url, init);
+  }
+  const warn = "window.PROXY is not defined; using direct fetch";
+  if (typeof fetch === "function") {
+    console.warn(warn);
+    return fetch(targetUrl, init);
+  }
+  const errMsg = "window.PROXY is not defined and fetch is unavailable";
+  console.error(errMsg);
+  throw new Error(errMsg);
 }
 
 // Attach to window for global consumption.

--- a/public/lib/treasury.js
+++ b/public/lib/treasury.js
@@ -8,6 +8,12 @@ function treasuryQuery(datasetPath, params = {}) {
   }
   const qs = search.toString();
   const url = `${TREASURY_BASE}/${datasetPath}${qs ? `?${qs}` : ''}`;
-  return window.proxiedFetch(url);
+  if (typeof window.proxiedFetch === 'function') {
+    return window.proxiedFetch(url);
+  }
+  const msg = 'proxiedFetch is not available';
+  console.error(msg);
+  if (typeof alert === 'function') alert(msg);
+  throw new Error(msg);
 }
 window.treasuryQuery = treasuryQuery;


### PR DESCRIPTION
## Summary
- Fallback to direct fetch when `window.PROXY` is missing and log descriptive errors
- Add runtime guards around helper functions like `proxiedFetch`, `fredSeriesObservations`, and others
- Ensure data helper modules check for `proxiedFetch` before using it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ce8ab11083229354e1636eaba477