### PR TITLE
Load library scripts without Babel

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,10 +64,10 @@
   <!-- App components and helper libraries (loaded via Babel in-browser) -->
   <script type="text/babel" data-presets="env,react" src="components/SourceNote.jsx"></script>
   <script type="text/babel" data-presets="env,react" src="public/config.js"></script>
-  <script type="text/babel" data-presets="env,react" src="public/lib/proxy.js"></script>
-  <script type="text/babel" data-presets="env,react" src="public/lib/bls.js"></script>
-  <script type="text/babel" data-presets="env,react" src="public/lib/fred.js"></script>
-  <script type="text/babel" data-presets="env,react" src="public/lib/treasury.js"></script>
+  <script type="text/javascript" src="public/lib/proxy.js"></script>
+  <script type="text/javascript" src="public/lib/bls.js"></script>
+  <script type="text/javascript" src="public/lib/fred.js"></script>
+  <script type="text/javascript" src="public/lib/treasury.js"></script>
   <script type="text/babel" data-presets="env,react" src="public/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove Babel processing for library scripts
- load helper libraries before main script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9cf9424708322b93bdc47335d862e