### PR TITLE
Add client-side proxy fetch helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
 
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="components/SourceNote.jsx"></script>
+  <script src="public/lib/proxy.js"></script>
   <script type="text/babel" data-presets="env,react" src="public/script.js"></script>
 </body>
 </html>

--- a/public/lib/proxy.js
+++ b/public/lib/proxy.js
@@ -1,0 +1,26 @@
+(function () {
+  /**
+   * Fetches a resource through a proxy defined by `window.PROXY`.
+   * @param {string} url - The URL to fetch.
+   * @param {RequestInit} [options] - Additional fetch options.
+   * @returns {Promise<Response>} Resolves with the response object.
+   */
+  async function proxiedFetch(url, options) {
+    if (!window || !window.PROXY) {
+      throw new Error('PROXY not configured');
+    }
+    if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+      throw new Error('URL must include protocol');
+    }
+    if (url.includes('..')) {
+      throw new Error('URL must not contain ".."');
+    }
+    try {
+      return await fetch(window.PROXY + encodeURIComponent(url), options);
+    } catch (err) {
+      throw err;
+    }
+  }
+
+  window.proxiedFetch = proxiedFetch;
+})();


### PR DESCRIPTION
## Summary
- add proxiedFetch helper to validate and fetch through configured proxy
- load helper before main script in index.html

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa04b1d6108322a8dfcaad046e7471