### PR TITLE
fix: correct mismatched parentheses in data panel

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1610,7 +1610,7 @@ function DataPanel({ onPlaceholders }) {
           React.createElement(Field, { label: "Start" }, /*#__PURE__*/
             React.createElement("input", { className: "field", type: "number", value: start, onChange: e => setStart(e.target.value), placeholder: "2010" })), /*#__PURE__*/
           React.createElement(Field, { label: "End" }, /*#__PURE__*/
-            React.createElement("input", { className: "field", type: "number", value: end, onChange: e => setEnd(e.target.value), placeholder: "2024" })))), /*#__PURE__*/
+            React.createElement("input", { className: "field", type: "number", value: end, onChange: e => setEnd(e.target.value), placeholder: "2024" }))), /*#__PURE__*/
         React.createElement("div", { className: "flex items-end gap-2" }, /*#__PURE__*/
           React.createElement("button", { className: "kbd", onClick: fetchEcon }, "Fetch Economic Data")), /*#__PURE__*/
         econData && /*#__PURE__*/React.createElement("div", { className: "result" }, /*#__PURE__*/


### PR DESCRIPTION
## Summary
- fix unmatched parentheses in DataPanel End field causing script parsing errors

## Testing
- `npm test`
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa09bd9a488322b7653266b9e4352f