### PR TITLE
Style DataPanel select inputs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1602,10 +1602,10 @@ function DataPanel({ onPlaceholders }) {
       React.createElement("div", { className: "mt-6 space-y-3" }, /*#__PURE__*/
         React.createElement("div", { className: "grid md:grid-cols-4 gap-3" }, /*#__PURE__*/
           React.createElement(Field, { label: "Series" }, /*#__PURE__*/
-            React.createElement("select", { className: "field", value: series, onChange: e => setSeries(e.target.value) }, /*#__PURE__*/
+            React.createElement("select", { className: "select", value: series, onChange: e => setSeries(e.target.value) }, /*#__PURE__*/
               Object.entries(ECON_SERIES).map(([id, label]) => /*#__PURE__*/React.createElement("option", { value: id, key: id }, label)))), /*#__PURE__*/
           React.createElement(Field, { label: "Frequency" }, /*#__PURE__*/
-            React.createElement("select", { className: "field", value: freq, onChange: e => setFreq(e.target.value) }, /*#__PURE__*/
+            React.createElement("select", { className: "select", value: freq, onChange: e => setFreq(e.target.value) }, /*#__PURE__*/
               Object.entries(FREQUENCIES).map(([id, label]) => /*#__PURE__*/React.createElement("option", { value: id, key: id }, label)))), /*#__PURE__*/
           React.createElement(Field, { label: "Start" }, /*#__PURE__*/
             React.createElement("input", { className: "field", type: "number", value: start, onChange: e => setStart(e.target.value), placeholder: "2010" })), /*#__PURE__*/

--- a/public/style.css
+++ b/public/style.css
@@ -40,7 +40,8 @@ body { background: var(--bg); color: var(--text); }
 
 .card { border:1px solid var(--border); background: var(--card-bg); border-radius:.75rem; box-shadow:0 1px 2px rgba(0,0,0,.04); }
 
-.field {
+.field,
+.select {
   width:100%;
   border:1px solid var(--border);
   border-radius:.625rem;
@@ -50,7 +51,8 @@ body { background: var(--bg); color: var(--text); }
   font-size:.925rem;
   color: var(--input-text);
 }
-.field:focus { outline:none; border-color:#6366f1; box-shadow: var(--ring); }
+.field:focus,
+.select:focus { outline:none; border-color:#6366f1; box-shadow: var(--ring); }
 
 .kbd {
   display:inline-flex;align-items:center;gap:.5rem;


### PR DESCRIPTION
## Summary
- Add `.select` CSS class mirroring `.field` styling for consistent padding, border, and rounded corners
- Use `className="select"` on DataPanel dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa0b21b2c483229ac7b7b04389ff2d