### PR TITLE
fix: load econ data helper script

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   <!-- Your app (JSX) -->
   <script type="text/babel" data-presets="env,react" src="components/SourceNote.jsx"></script>
   <script src="public/lib/proxy.js"></script>
+  <script src="public/lib/econ.js"></script>
   <script type="text/babel" data-presets="env,react" src="public/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load `public/lib/econ.js` so economic data fetch helper is available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa0eb10a1c832282c24cfc63750755