### PR TITLE
Add backend state tax calculations for 2025 brackets

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const { calcStateTax } = require('./stateTax');
 
 const app = express();
 
@@ -14,6 +15,18 @@ app.locals.investorProfile = INVESTOR_PROFILE;
 app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use('/components', express.static(path.join(__dirname, 'components')));
 app.use('/sim', express.static(path.join(__dirname, 'sim')));
+
+app.get('/api/state-tax', (req, res) => {
+  const { state, status, income, overrideRate } = req.query;
+  const incomeNum = Number(income);
+  if (!state || !Number.isFinite(incomeNum)) {
+    return res.status(400).json({ error: 'state and income required' });
+  }
+  const override = overrideRate !== undefined ? Number(overrideRate) : NaN;
+  const result = calcStateTax(state, status, incomeNum, override);
+  res.json(result);
+});
+
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
 });

--- a/stateTax.js
+++ b/stateTax.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadBrackets(file) {
+  const text = fs.readFileSync(file, 'utf8').trim();
+  const lines = text.split(/\r?\n/);
+  lines.shift(); // header
+  const data = {};
+  for (const line of lines) {
+    if (!line) continue;
+    const [state, bracketIndex, threshold, rate] = line.split(',');
+    if (!data[state]) data[state] = [];
+    data[state].push({ threshold: Number(threshold), rate: Number(rate) });
+  }
+  for (const st of Object.keys(data)) {
+    data[st].sort((a, b) => a.threshold - b.threshold);
+  }
+  return data;
+}
+
+const single = loadBrackets(path.join(__dirname, 'state taxes', 'state_taxes_single_long.csv'));
+const married = loadBrackets(path.join(__dirname, 'state taxes', 'state_taxes_married_joint_long.csv'));
+
+function calcStateTax(state, status, income, overrideRate) {
+  if (Number.isFinite(overrideRate)) {
+    const tax = income > 0 ? income * overrideRate : 0;
+    return { tax, effectiveRate: overrideRate };
+  }
+  const table = status === 'Married Filing Jointly' ? married : single;
+  const brackets = table[state];
+  if (!brackets || income <= 0) return { tax: 0, effectiveRate: 0 };
+  let tax = 0;
+  for (let i = 0; i < brackets.length; i++) {
+    const { threshold, rate } = brackets[i];
+    const upper = i < brackets.length - 1 ? brackets[i + 1].threshold - 1e-9 : Infinity;
+    if (income > threshold) {
+      const amt = Math.min(income, upper) - threshold;
+      tax += amt * rate;
+    } else {
+      break;
+    }
+  }
+  const effectiveRate = tax / income;
+  return { tax, effectiveRate };
+}
+
+module.exports = { calcStateTax };


### PR DESCRIPTION
## Summary
- compute progressive state tax from 2025 brackets
- expose `/api/state-tax` endpoint for effective rate lookups
- update tax calculator to fetch and display state tax estimates automatically
- allow users to override state tax rate and cite Tax Foundation as data source

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade135a5f4832288b5e979bb9cdec8