### PR TITLE
Calculate state taxes client-side and clamp Monte Carlo balances

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ app.locals.investorProfile = INVESTOR_PROFILE;
 app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use('/components', express.static(path.join(__dirname, 'components')));
 app.use('/sim', express.static(path.join(__dirname, 'sim')));
+app.use('/state taxes', express.static(path.join(__dirname, 'state taxes')));
 
 app.get('/api/state-tax', (req, res) => {
   const { state, status, income, overrideRate } = req.query;


### PR DESCRIPTION
## Summary
- Compute state income tax in the browser using bracket CSVs so the rate updates with user inputs even without the API
- Expose state tax CSVs via Express for local development
- Prevent Monte Carlo simulation balances from dropping below $0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade7e32d3c83228a547c01a1caa0b2