### PR TITLE
Handle unsupported state tax statuses

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1029,6 +1029,9 @@ async function calcStateTaxClient(state, status, income, overrideRate) {
     const tax = income > 0 ? income * overrideRate : 0;
     return { tax, effectiveRate: overrideRate };
   }
+  if (status !== 'Single' && status !== 'Married Filing Jointly') {
+    return { tax: 0, effectiveRate: 0, manual: true };
+  }
   const table = await loadStateTable(status);
   const brackets = table[state];
   if (!brackets || income <= 0) return { tax: 0, effectiveRate: 0 };

--- a/server.js
+++ b/server.js
@@ -25,6 +25,9 @@ app.get('/api/state-tax', (req, res) => {
   }
   const override = overrideRate !== undefined ? Number(overrideRate) : NaN;
   const result = calcStateTax(state, status, incomeNum, override);
+  if (result.manual) {
+    return res.json({ ...result, message: 'Unsupported filing status; please enter rate manually' });
+  }
   res.json(result);
 });
 

--- a/stateTax.js
+++ b/stateTax.js
@@ -26,6 +26,9 @@ function calcStateTax(state, status, income, overrideRate) {
     const tax = income > 0 ? income * overrideRate : 0;
     return { tax, effectiveRate: overrideRate };
   }
+  if (status !== 'Single' && status !== 'Married Filing Jointly') {
+    return { tax: 0, effectiveRate: 0, manual: true };
+  }
   const table = status === 'Married Filing Jointly' ? married : single;
   const brackets = table[state];
   if (!brackets || income <= 0) return { tax: 0, effectiveRate: 0 };


### PR DESCRIPTION
## Summary
- Guard state tax calculations so brackets are only computed for "Single" or "Married Filing Jointly" and flag other statuses for manual rates.
- Add client-side parity for unsupported statuses in `calcStateTaxClient`.
- API now returns a notice when a manual rate is required.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adf3b9e46c8322afa99205ddc8af6c