### PR TITLE
Fix tax calculator UI syntax error

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1173,7 +1173,7 @@ function TaxCalc() {
     React.createElement("div", { className: "grid md:grid-cols-3 gap-3 mt-3" }, /*#__PURE__*/
     React.createElement("div", { className: "result result-secondary" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Federal tax (est.)"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(fedTotal)), /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Ordinary: ", money0(fedOrd), " \xB7 LTCG/QD: ", money0(fedCG))), /*#__PURE__*/
     React.createElement("div", { className: "result result-secondary" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "State income tax (est.)"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(stateTax))), /*#__PURE__*/
-    React.createElement("div", { className: "result result-secondary" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Other W-2 taxes (est.)"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(ficaTax)), /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "SS: ", money0(ssTax), " \xB7 Medicare: ", money0(medTax + addlMedTax)))))));
+    React.createElement("div", { className: "result result-secondary" }, /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "Other W-2 taxes (est.)"), /*#__PURE__*/React.createElement("div", { className: "text-lg font-semibold" }, money0(ficaTax)), /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500" }, "SS: ", money0(ssTax), " \xB7 Medicare: ", money0(medTax + addlMedTax))))));
 
 
 


### PR DESCRIPTION
## Summary
- Correct closing parentheses in `public/script.js` to restore tax calculator rendering.
- Verified Nebraska single $100k income state tax: $4,722 (4.72% effective rate).

## Testing
- `node --check public/script.js`
- `npm test`
- `node -e "const {calcStateTax}=require('./stateTax'); console.log(calcStateTax('NE','Single',100000));"`


------
https://chatgpt.com/codex/tasks/task_e_68adf15a0c088322928925156b774249