### PR TITLE
Fix unmatched parentheses in state tax override UI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1158,7 +1158,7 @@ function TaxCalc() {
     React.createElement("div", { className: "text-xs text-slate-500" }, useCustomRate && Number.isFinite(customRate) ? 'Using override' : suggestion.msg)), /*#__PURE__*/
     React.createElement(Field, { label: "Manually enter rate" }, /*#__PURE__*/React.createElement("input", { type: "checkbox", className: "h-4 w-4", checked: useCustomRate, onChange: e => setUseCustomRate(e.target.checked), disabled: customRateForced })),
     customRateForced && /*#__PURE__*/React.createElement("div", { className: "text-xs text-slate-500 sm:col-span-2" }, "State tax rate must be entered manually for this filing status; calculator currently supports only Single or Married Filing Jointly."),
-    useCustomRate && /*#__PURE__*/React.createElement(Field, { label: "Override rate (%)" }, /*#__PURE__*/React.createElement(PercentInput, { value: customRate, onChange: setCustomRate, placeholder: suggestion.rate.toFixed(2) })))), /*#__PURE__*/
+    useCustomRate && /*#__PURE__*/React.createElement(Field, { label: "Override rate (%)" }, /*#__PURE__*/React.createElement(PercentInput, { value: customRate, onChange: setCustomRate, placeholder: suggestion.rate.toFixed(2) }))), /*#__PURE__*/
 
     React.createElement("p", { className: "text-xs text-slate-600 mt-2" }, "This is a simple effective-rate estimate (credits/AMT/NIIT not included)."), /*#__PURE__*/
     React.createElement("p", { className: "text-[11px] text-slate-500 mt-1" }, "Source: ", /*#__PURE__*/React.createElement("a", { href: "https://taxfoundation.org/data/all/state/state-income-tax-rates/", target: "_blank", rel: "noreferrer", className: "underline" }, "Tax Foundation")))), /*#__PURE__*/


### PR DESCRIPTION
## Summary
- fix unmatched parentheses in tax calculator's state override section so component renders correctly

## Testing
- `node --check public/script.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfb58e7d883229ec58dbd0ab9cfb9