### PR TITLE
Fix state tax table loading

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1004,9 +1004,12 @@ async function loadStateTable(status) {
   if (STATE_TAX_CACHE[key]) return STATE_TAX_CACHE[key];
   const file =
     key === 'married'
-      ? '/state%20taxes/state_taxes_married_joint_long.csv'
-      : '/state%20taxes/state_taxes_single_long.csv';
+      ? 'state%20taxes/state_taxes_married_joint_long.csv'
+      : 'state%20taxes/state_taxes_single_long.csv';
   const res = await fetch(file);
+  if (!res.ok) {
+    throw new Error(`Failed to load state tax table: ${res.status}`);
+  }
   const text = await res.text();
   const lines = text.trim().split(/\r?\n/);
   lines.shift(); // header


### PR DESCRIPTION
## Summary
- load state tax CSVs using a relative path so they resolve in subdirectory deployments
- throw an explicit error when the CSV fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfd25866c8322872ecefc46455de7